### PR TITLE
Properly initialize libgcrypt on start

### DIFF
--- a/crypto/err.h
+++ b/crypto/err.h
@@ -25,4 +25,10 @@
 
 void TGLC_err_print_errors_fp (FILE *fp);
 
+// Don't want to include tgl.h just for this
+struct tgl_state;
+
+// Init crypto backend, log to TLS
+int TGLC_init (struct tgl_state *TLS);
+
 #endif

--- a/crypto/err_openssl.c
+++ b/crypto/err_openssl.c
@@ -30,4 +30,10 @@ void TGLC_err_print_errors_fp (FILE *fp) {
   ERR_print_errors_fp (fp);
 }
 
+int TGLC_init (void) {
+  // Doesn't seem to need any initialization.
+  vlogprintf (E_DEBUG, "Init OpenSSL (no-op)\n");
+  return !0;
+}
+
 #endif

--- a/tgl.c
+++ b/tgl.c
@@ -22,6 +22,7 @@
 #include "config.h"
 #endif
 
+#include "crypto/err.h"
 #include "crypto/rsa_pem.h"
 #include "tgl.h"
 #include "tools.h"
@@ -82,10 +83,14 @@ int tgl_init (struct tgl_state *TLS) {
   TLS->message_list.next_use = &TLS->message_list;
   TLS->message_list.prev_use = &TLS->message_list;
 
+  if (TGLC_init (TLS) != 0) {
+    return -1;
+  }
+
   if (tglmp_on_start (TLS) < 0) {
     return -1;
   }
-  
+
   if (!TLS->app_id) {
     TLS->app_id = TG_APP_ID;
     TLS->app_hash = tstrdup (TG_APP_HASH);


### PR DESCRIPTION
Cherry pick from https://github.com/vysheng/tgl/pull/94

Otherwise, this spews an ugly warning, e.g. in Finch:
Libgcrypt warning: missing initialization - please fix the application

Sorry that I didn't implement proper initialization from the start, I thought I could get away without it :P