### PR TITLE
Fix build on solaris (-Werror=return-type)

### DIFF
--- a/auto-static-autocomplete.c
+++ b/auto-static-autocomplete.c
@@ -43,6 +43,7 @@ int tglf_extf_autocomplete (struct tgl_state *TLS, const char *text, int text_le
 #ifdef DISABLE_EXTF
   (void) free_vars_to_be_freed;
   assert (0);
+  return 0;
 #else
   if (index == -1) {
     buffer_pos = data;

--- a/auto-static-fetch.c
+++ b/auto-static-fetch.c
@@ -106,6 +106,7 @@ static void print_offset (void) {
 char *tglf_extf_fetch (struct tgl_state *TLS, struct paramed_type *T) {
 #ifdef DISABLE_EXTF
   assert (0);
+  return 0;
 #else
   out_buf_pos = 0;
   if (fetch_type_any (T) < 0) { return 0; }

--- a/auto-static-store.c
+++ b/auto-static-store.c
@@ -253,6 +253,7 @@ void tgl_paramed_type_free (struct paramed_type *P);
 struct paramed_type *tglf_extf_store (struct tgl_state *TLS, const char *data, int data_len) { 
 #ifdef DISABLE_EXTF
   assert (0);
+  return 0;
 #else
   buffer_pos = (char *)data;
   buffer_end = (char *)(data + data_len);


### PR DESCRIPTION
Errors like this 

    ./auto-static-autocomplete.c:72:1: error: control reaches end of non-void function [-Werror=return-type]