### PR TITLE
fixup! Properly initialize libgcrypt on start

### DIFF
--- a/crypto/err_openssl.c
+++ b/crypto/err_openssl.c
@@ -24,15 +24,17 @@
 
 #include <openssl/err.h>
 
+#include "../tgl.h"
+#include "../tgl-inner.h"
 #include "err.h"
 
 void TGLC_err_print_errors_fp (FILE *fp) {
   ERR_print_errors_fp (fp);
 }
 
-int TGLC_init (void) {
+int TGLC_init (struct tgl_state *TLS) {
   // Doesn't seem to need any initialization.
-  vlogprintf (E_DEBUG, "Init OpenSSL (no-op)\n");
+  vlogprintf (6, "Init OpenSSL (no-op)\n");
   return !0;
 }
 


### PR DESCRIPTION
Credits to Travis for noticing this bug, as we usually compile *only* for gcrypt.