### PR TITLE
32-bit runtime assert fix

### DIFF
--- a/mtproto-utils.c
+++ b/mtproto-utils.c
@@ -98,7 +98,6 @@ static unsigned long long BN2ull (TGLC_bn *b) {
   if (sizeof (unsigned long) == 8) {
     return TGLC_bn_get_word (b);
   } else if (sizeof (unsigned long long) == 8) {
-    assert (0); // As long as nobody ever uses this code, assume it is broken.
     unsigned long long tmp;
     /* Here be dragons, but it should be okay due to be64toh */
     TGLC_bn_bn2bin (b, (unsigned char *) &tmp);
@@ -112,8 +111,7 @@ static void ull2BN (TGLC_bn *b, unsigned long long val) {
   if (sizeof (unsigned long) == 8 || val < (1ll << 32)) {
     TGLC_bn_set_word (b, val);
   } else if (sizeof (unsigned long long) == 8) {
-    assert (0); // As long as nobody ever uses this code, assume it is broken.
-    htobe64(val);
+    val = htobe64(val);
     /* Here be dragons, but it should be okay due to htobe64 */
     TGLC_bn_bin2bn ((unsigned char *) &val, 8, b);
   } else {


### PR DESCRIPTION
32-bit builds of libtgl were assert()ing when calling the BN2ull()/ull2BN() functions.  This had the effect of not being able to login to telegram-purple on 32-bit machines.

Pidgin on Windows is a 32-bit application, which is why it was running into this problem. 