### PR TITLE
Enable stack smashing protection

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -4,7 +4,7 @@ CFLAGS=@CFLAGS@
 LDFLAGS=@LDFLAGS@ @OPENSSL_LDFLAGS@
 CPPFLAGS=@CPPFLAGS@ @OPENSSL_INCLUDES@
 DEFS=@DEFS@
-COMPILE_FLAGS=${CFLAGS} ${CPFLAGS} ${CPPFLAGS} ${DEFS} -Wall -Wextra -Werror -Wno-deprecated-declarations -fno-strict-aliasing -fno-omit-frame-pointer -ggdb -Wno-unused-parameter -fPIC -fstack-protector-strong -D_FORTIFY_SOURCE=2
+COMPILE_FLAGS=${CFLAGS} ${CPFLAGS} ${CPPFLAGS} ${DEFS} -Wall -Wextra -Werror -Wno-deprecated-declarations -fno-strict-aliasing -fno-omit-frame-pointer -ggdb -Wno-unused-parameter -fPIC -D_FORTIFY_SOURCE=2
 
 EXTRA_LIBS=@LIBS@ @EXTRA_LIBS@ @OPENSSL_LIBS@
 LOCAL_LDFLAGS=-rdynamic -ggdb ${EXTRA_LIBS}
@@ -31,6 +31,13 @@ DEPENDENCE_LIST=${DEPENDENCE}
 
 INCLUDE=-I. -I${srcdir}
 CC=@CC@
+
+ifeq "$(CC)" "gcc"
+GCCVERGEQ5 := $(shell expr `$(CC) -dumpversion | cut -f1 -d.` \>= 5)
+ifeq "$(GCCVERGEQ5)" "1"
+	COMPILE_FLAGS += -fstack-protector-strong
+endif
+endif
 
 .SUFFIXES:
 

--- a/Makefile.in
+++ b/Makefile.in
@@ -4,7 +4,7 @@ CFLAGS=@CFLAGS@
 LDFLAGS=@LDFLAGS@ @OPENSSL_LDFLAGS@
 CPPFLAGS=@CPPFLAGS@ @OPENSSL_INCLUDES@
 DEFS=@DEFS@
-COMPILE_FLAGS=${CFLAGS} ${CPFLAGS} ${CPPFLAGS} ${DEFS} -Wall -Wextra -Werror -Wno-deprecated-declarations -fno-strict-aliasing -fno-omit-frame-pointer -ggdb -Wno-unused-parameter -fPIC
+COMPILE_FLAGS=${CFLAGS} ${CPFLAGS} ${CPPFLAGS} ${DEFS} -Wall -Wextra -Werror -Wno-deprecated-declarations -fno-strict-aliasing -fno-omit-frame-pointer -ggdb -Wno-unused-parameter -fPIC -fstack-protector-strong -D_FORTIFY_SOURCE=2
 
 EXTRA_LIBS=@LIBS@ @EXTRA_LIBS@ @OPENSSL_LIBS@
 LOCAL_LDFLAGS=-rdynamic -ggdb ${EXTRA_LIBS}

--- a/Makefile.in
+++ b/Makefile.in
@@ -32,11 +32,10 @@ DEPENDENCE_LIST=${DEPENDENCE}
 INCLUDE=-I. -I${srcdir}
 CC=@CC@
 
-ifeq "$(CC)" "gcc"
-GCCVERGEQ5 := $(shell expr `$(CC) -dumpversion | cut -f1 -d.` \>= 5)
-ifeq "$(GCCVERGEQ5)" "1"
+# Check if -fstack-protector-strong is supported before enabling it
+SPUNSUPPORTED = $(shell $(CC) -fstack-protector-strong 2>&1 | grep -c 'stack-protector-strong')
+ifeq "$(SPUNSUPPORTED)" "0"
 	COMPILE_FLAGS += -fstack-protector-strong
-endif
 endif
 
 .SUFFIXES:


### PR DESCRIPTION
This PR adds compiler flags "-fstack-protector-strong" and "-D_FORTIFY_SOURCE=2". 
They increase security of the library and allow developers to find buffer overflows more easily. 
