### PR TITLE
Out of source fix

### DIFF
--- a/crypto/aes.h
+++ b/crypto/aes.h
@@ -23,7 +23,7 @@
 
 #include <stddef.h> /* size_t */
 
-#include "../config.h"
+#include "config.h"
 
 typedef struct TGLC_aes_key {
   char _dummy[

--- a/crypto/aes_altern.c
+++ b/crypto/aes_altern.c
@@ -18,7 +18,7 @@
     Copyright Ben Wiederhake 2015
 */
 
-#include "../config.h"
+#include "config.h"
 
 #ifdef TGL_AVOID_OPENSSL
 

--- a/crypto/aes_openssl.c
+++ b/crypto/aes_openssl.c
@@ -18,7 +18,7 @@
     Copyright Ben Wiederhake 2015
 */
 
-#include "../config.h"
+#include "config.h"
 
 #ifndef TGL_AVOID_OPENSSL
 

--- a/crypto/bn_altern.c
+++ b/crypto/bn_altern.c
@@ -18,7 +18,7 @@
     Copyright Ben Wiederhake 2015
 */
 
-#include "../config.h"
+#include "config.h"
 
 #ifdef TGL_AVOID_OPENSSL
 

--- a/crypto/bn_openssl.c
+++ b/crypto/bn_openssl.c
@@ -18,7 +18,7 @@
     Copyright Ben Wiederhake 2015
 */
 
-#include "../config.h"
+#include "config.h"
 
 #ifndef TGL_AVOID_OPENSSL
 

--- a/crypto/err_altern.c
+++ b/crypto/err_altern.c
@@ -18,7 +18,7 @@
     Copyright Ben Wiederhake 2015
 */
 
-#include "../config.h"
+#include "config.h"
 
 #ifdef TGL_AVOID_OPENSSL
 

--- a/crypto/err_openssl.c
+++ b/crypto/err_openssl.c
@@ -18,7 +18,7 @@
     Copyright Ben Wiederhake 2015
 */
 
-#include "../config.h"
+#include "config.h"
 
 #ifndef TGL_AVOID_OPENSSL
 

--- a/crypto/md5_altern.c
+++ b/crypto/md5_altern.c
@@ -18,7 +18,7 @@
     Copyright Ben Wiederhake 2015
 */
 
-#include "../config.h"
+#include "config.h"
 
 #ifdef TGL_AVOID_OPENSSL
 

--- a/crypto/md5_openssl.c
+++ b/crypto/md5_openssl.c
@@ -18,7 +18,7 @@
     Copyright Ben Wiederhake 2015
 */
 
-#include "../config.h"
+#include "config.h"
 
 #ifndef TGL_AVOID_OPENSSL
 

--- a/crypto/rand_altern.c
+++ b/crypto/rand_altern.c
@@ -18,7 +18,7 @@
     Copyright Ben Wiederhake 2015
 */
 
-#include "../config.h"
+#include "config.h"
 
 #ifdef TGL_AVOID_OPENSSL
 

--- a/crypto/rand_openssl.c
+++ b/crypto/rand_openssl.c
@@ -18,7 +18,7 @@
     Copyright Ben Wiederhake 2015
 */
 
-#include "../config.h"
+#include "config.h"
 
 #ifndef TGL_AVOID_OPENSSL
 

--- a/crypto/rsa_pem_altern.c
+++ b/crypto/rsa_pem_altern.c
@@ -18,7 +18,7 @@
     Copyright Ben Wiederhake 2015
 */
 
-#include "../config.h"
+#include "config.h"
 
 #ifdef TGL_AVOID_OPENSSL
 

--- a/crypto/rsa_pem_openssl.c
+++ b/crypto/rsa_pem_openssl.c
@@ -18,7 +18,7 @@
     Copyright Ben Wiederhake 2015
 */
 
-#include "../config.h"
+#include "config.h"
 
 #ifndef TGL_AVOID_OPENSSL
 

--- a/crypto/sha_altern.c
+++ b/crypto/sha_altern.c
@@ -18,7 +18,7 @@
     Copyright Ben Wiederhake 2015
 */
 
-#include "../config.h"
+#include "config.h"
 
 #ifdef TGL_AVOID_OPENSSL
 

--- a/crypto/sha_openssl.c
+++ b/crypto/sha_openssl.c
@@ -18,7 +18,7 @@
     Copyright Ben Wiederhake 2015
 */
 
-#include "../config.h"
+#include "config.h"
 
 #ifndef TGL_AVOID_OPENSSL
 

--- a/structures.c
+++ b/structures.c
@@ -514,7 +514,7 @@ struct tgl_chat *tglf_fetch_alloc_chat (struct tgl_state *TLS, struct tl_ds_chat
   if (DS_C->magic == CODE_chat_empty) { 
     return NULL;
   }
-  if (DS_C->magic == CODE_channel) {
+  if (DS_C->magic == CODE_channel || DS_C->magic == CODE_channel_forbidden) {
     return (void *)tglf_fetch_alloc_channel (TLS, DS_C);
   }
   tgl_peer_id_t chat_id = TGL_MK_CHAT (DS_LVAL (DS_C->id));  
@@ -1548,7 +1548,8 @@ struct tgl_message *tglf_fetch_alloc_message (struct tgl_state *TLS, struct tl_d
   tgl_peer_t *FF = NULL;
 
   if (DS_M->fwd_from_id) {
-    FF = tgl_peer_get (TLS, tglf_fetch_peer_id (TLS, DS_M->fwd_from_id));
+    tgl_peer_id_t FF_id = tglf_fetch_peer_id (TLS, DS_M->fwd_from_id); 
+    FF = tgl_peer_get (TLS, FF_id);    
     if (!FF) {
       tgl_do_get_difference (TLS, 0, 0, 0);
       vlogprintf (E_NOTICE, "unknown fwd_id\n");


### PR DESCRIPTION
Don't use relative path to config.h, so that out-of source tree compiles works fine. (Main source directory is already included in -I compiler flags).