### PR TITLE
make tgl work with openssl

### DIFF
--- a/crypto/err_openssl.c
+++ b/crypto/err_openssl.c
@@ -35,7 +35,7 @@ void TGLC_err_print_errors_fp (FILE *fp) {
 int TGLC_init (struct tgl_state *TLS) {
   // Doesn't seem to need any initialization.
   vlogprintf (6, "Init OpenSSL (no-op)\n");
-  return !0;
+  return 0;
 }
 
 #endif


### PR DESCRIPTION
Telegram-purple doesn't work, If you configure and build it without gcrypt. TGLC_init function never return successful code.

Looks like [this issue](https://github.com/majn/telegram-purple/issues/327) related to this fix.