### PR TITLE
Linux cross compile support

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -7,8 +7,12 @@ DEFS=@DEFS@
 COMPILE_FLAGS=${CFLAGS} ${CPFLAGS} ${CPPFLAGS} ${DEFS} -Wall -Wextra -Wno-deprecated-declarations -fno-strict-aliasing -fno-omit-frame-pointer -ggdb -Wno-unused-parameter -fPIC -D_FORTIFY_SOURCE=2
 
 EXTRA_LIBS=@LIBS@ @EXTRA_LIBS@ @OPENSSL_LIBS@
-LOCAL_LDFLAGS=-rdynamic -ggdb ${EXTRA_LIBS}
+LOCAL_LDFLAGS=-rdynamic -ggdb ${EXTRA_LIBS} -fPIC
 LINK_FLAGS=${LDFLAGS} ${LOCAL_LDFLAGS}
+
+#Cross compile
+CROSS_COMPILE_BUILD=@CROSS_COMPILE_BUILD@
+PREFIX_BUILD=@PREFIX_BUILD@
 
 DEP=dep
 AUTO=auto
@@ -36,6 +40,20 @@ CC=@CC@
 SPUNSUPPORTED = $(shell $(CC) -fstack-protector-strong 2>&1 | grep -c 'stack-protector-strong')
 ifeq "$(SPUNSUPPORTED)" "0"
 	COMPILE_FLAGS += -fstack-protector-strong
+endif
+
+#TGL_GENERATE=${OBJ}/generate.native.o ${OBJ}/tools.native.o ${OBJ}/crypto/rand_openssl.native.o ${OBJ}/crypto/rand_altern.native.o ${OBJ}/crypto/err_openssl.native.o ${OBJ}/crypto/err_altern.native.o
+TGL_GENERATE=$(subst .o,.native.o,$(GENERATE_OBJECTS)) $(subst .o,.native.o,$(COMMON_OBJECTS))
+
+ifdef CROSS_COMPILE_BUILD
+	CC_BUILD = $(CROSS_COMPILE_BUILD)-gcc
+# 	Replace with build machine paths
+	COMPILE_FLAGS_BUILD := $(subst $(PREFIX_BUILD),/usr/local,$(COMPILE_FLAGS))
+	LINK_FLAGS_BUILD := $(subst $(PREFIX_BUILD),/usr/local,$(LINK_FLAGS))
+else
+	CC_BUILD = $(CC)
+	COMPILE_FLAGS_BUILD = ${COMPILE_FLAGS}
+	LINK_FLAGS_BUILD = $(LINK_FLAGS)
 endif
 
 .SUFFIXES:
@@ -68,8 +86,11 @@ ${LIB}/libtgl.a: ${TGL_OBJECTS} ${COMMON_OBJECTS} ${TGL_OBJECTS_AUTO}
 ${LIB}/libtgl.so: ${TGL_OBJECTS} ${COMMON_OBJECTS} ${TGL_OBJECTS_AUTO}
 	${CC} -shared -o $@ $^ ${LINK_FLAGS}
 
-${EXE}/generate: ${GENERATE_OBJECTS} ${COMMON_OBJECTS}
-	${CC} ${GENERATE_OBJECTS} ${COMMON_OBJECTS} ${LINK_FLAGS} -o $@
+${TGL_GENERATE}: ${OBJ}/%.native.o: ${srcdir}/%.c | create_dirs
+	${CC_BUILD} ${INCLUDE} ${COMPILE_FLAGS_BUILD} -c -MP -MD -MF ${DEP}/$*.native.d -MQ ${OBJ}/$*.native.o -o $@ $<
+	
+${EXE}/generate: ${TGL_GENERATE}
+	${CC_BUILD} ${TGL_GENERATE} ${LINK_FLAGS_BUILD} -o $@
 
 ${AUTO}/scheme.tlo: ${AUTO}/scheme.tl ${EXE}/tl-parser
 	${EXE}/tl-parser -e $@ ${AUTO}/scheme.tl

--- a/Makefile.tl-parser
+++ b/Makefile.tl-parser
@@ -1,7 +1,18 @@
 TL_PARSER_OBJECTS=${OBJ}/tl-parser.o ${OBJ}/tlc.o
 
+ifdef CROSS_COMPILE_BUILD
+	CC_BUILD = $(CROSS_COMPILE_BUILD)-gcc
+# 	Replace with build machine paths
+	COMPILE_FLAGS_BUILD := $(subst $(PREFIX_BUILD),/usr/local,$(COMPILE_FLAGS))
+	LINK_FLAGS_BUILD := $(subst $(PREFIX_BUILD),/usr/local,$(LINK_FLAGS))
+else
+	CC_BUILD = $(CC)
+	COMPILE_FLAGS_BUILD = ${COMPILE_FLAGS}
+	LINK_FLAGS_BUILD = $(LINK_FLAGS)
+endif
+
 ${TL_PARSER_OBJECTS}: ${OBJ}/%.o: ${srcdir}/tl-parser/%.c | create_dirs
-	${CC} ${INCLUDE} ${COMPILE_FLAGS} -iquote ${srcdir}/tl-parser -c -MP -MD -MF ${DEP}/$*.d -MQ ${OBJ}/$*.o -o $@ $<
+	${CC_BUILD} ${INCLUDE} ${COMPILE_FLAGS_BUILD} -iquote ${srcdir}/tl-parser -c -MP -MD -MF ${DEP}/$*.d -MQ ${OBJ}/$*.o -o $@ $<
 
 ${EXE}/tl-parser: ${TL_PARSER_OBJECTS}
-	${CC} $^ ${LINK_FLAGS} -o $@
+	${CC_BUILD} $^ ${LINK_FLAGS_BUILD} -o $@

--- a/configure
+++ b/configure
@@ -621,6 +621,8 @@ ac_includes_default="\
 
 ac_subst_vars='LTLIBOBJS
 LIBOBJS
+PREFIX_BUILD
+CROSS_COMPILE_BUILD
 EXTRA_OBJECTS
 EXTRA_LIBS
 EGREP
@@ -2165,7 +2167,7 @@ ac_config_headers="$ac_config_headers config.h"
 
 
 # ===========================================================================
-#     http://www.gnu.org/software/autoconf-archive/ax_check_openssl.html
+#     https://www.gnu.org/software/autoconf-archive/ax_check_openssl.html
 # ===========================================================================
 #
 # SYNOPSIS
@@ -2198,7 +2200,7 @@ ac_config_headers="$ac_config_headers config.h"
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 8
+#serial 10_patch_8498
 
 # This is what autoupdate's m4 run will expand.  It fires
 # the warning (with _au_warn_XXX), outputs it into the
@@ -3100,9 +3102,21 @@ ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $
 ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
 
+#TODO do it better...
+PREFIX_BUILD=${prefix}
+CROSS_COMPILE_BUILD=${build}
+
+if [ "x$cross_compiling" = "xno" ]; then
+    PREFIX_BUILD="/usr/local"
+fi
+
 # BSD locations for headers and libraries from packages, Linux locations for self-compiled stuff.
-CPPFLAGS="$CPPFLAGS -I/usr/local/include"
-LDFLAGS="$LDFLAGS -L/usr/local/lib"
+CPPFLAGS="$CPPFLAGS -I${PREFIX_BUILD}/include"
+LDFLAGS="$LDFLAGS -L${PREFIX_BUILD}/lib"
+
+#Backup variables
+CPPFLAGS_BUILD=$CPPFLAGS
+LDFLAGS_BUILD=$LDFLAGS
 
 # Checks for libraries.
 
@@ -3244,26 +3258,25 @@ else
 
             # if pkg-config is installed and openssl has installed a .pc file,
             # then use that information and don't search ssldirs
-            # Extract the first word of "pkg-config", so it can be a program name with args.
-set dummy pkg-config; ac_word=$2
+            if test -n "$ac_tool_prefix"; then
+  # Extract the first word of "${ac_tool_prefix}pkg-config", so it can be a program name with args.
+set dummy ${ac_tool_prefix}pkg-config; ac_word=$2
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
 $as_echo_n "checking for $ac_word... " >&6; }
-if ${ac_cv_path_PKG_CONFIG+:} false; then :
+if ${ac_cv_prog_PKG_CONFIG+:} false; then :
   $as_echo_n "(cached) " >&6
 else
-  case $PKG_CONFIG in
-  [\\/]* | ?:[\\/]*)
-  ac_cv_path_PKG_CONFIG="$PKG_CONFIG" # Let the user override the test with a path.
-  ;;
-  *)
-  as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+  if test -n "$PKG_CONFIG"; then
+  ac_cv_prog_PKG_CONFIG="$PKG_CONFIG" # Let the user override the test.
+else
+as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
 for as_dir in $PATH
 do
   IFS=$as_save_IFS
   test -z "$as_dir" && as_dir=.
     for ac_exec_ext in '' $ac_executable_extensions; do
   if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
-    ac_cv_path_PKG_CONFIG="$as_dir/$ac_word$ac_exec_ext"
+    ac_cv_prog_PKG_CONFIG="${ac_tool_prefix}pkg-config"
     $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
     break 2
   fi
@@ -3271,10 +3284,9 @@ done
   done
 IFS=$as_save_IFS
 
-  ;;
-esac
 fi
-PKG_CONFIG=$ac_cv_path_PKG_CONFIG
+fi
+PKG_CONFIG=$ac_cv_prog_PKG_CONFIG
 if test -n "$PKG_CONFIG"; then
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: $PKG_CONFIG" >&5
 $as_echo "$PKG_CONFIG" >&6; }
@@ -3283,6 +3295,60 @@ else
 $as_echo "no" >&6; }
 fi
 
+
+fi
+if test -z "$ac_cv_prog_PKG_CONFIG"; then
+  ac_ct_PKG_CONFIG=$PKG_CONFIG
+  # Extract the first word of "pkg-config", so it can be a program name with args.
+set dummy pkg-config; ac_word=$2
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_prog_ac_ct_PKG_CONFIG+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  if test -n "$ac_ct_PKG_CONFIG"; then
+  ac_cv_prog_ac_ct_PKG_CONFIG="$ac_ct_PKG_CONFIG" # Let the user override the test.
+else
+as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+for as_dir in $PATH
+do
+  IFS=$as_save_IFS
+  test -z "$as_dir" && as_dir=.
+    for ac_exec_ext in '' $ac_executable_extensions; do
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
+    ac_cv_prog_ac_ct_PKG_CONFIG="pkg-config"
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
+    break 2
+  fi
+done
+  done
+IFS=$as_save_IFS
+
+fi
+fi
+ac_ct_PKG_CONFIG=$ac_cv_prog_ac_ct_PKG_CONFIG
+if test -n "$ac_ct_PKG_CONFIG"; then
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_ct_PKG_CONFIG" >&5
+$as_echo "$ac_ct_PKG_CONFIG" >&6; }
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+fi
+
+  if test "x$ac_ct_PKG_CONFIG" = x; then
+    PKG_CONFIG=""
+  else
+    case $cross_compiling:$ac_tool_warned in
+yes:)
+{ $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with host triplet" >&5
+$as_echo "$as_me: WARNING: using cross tools not prefixed with host triplet" >&2;}
+ac_tool_warned=yes ;;
+esac
+    PKG_CONFIG=$ac_ct_PKG_CONFIG
+  fi
+else
+  PKG_CONFIG="$ac_cv_prog_PKG_CONFIG"
+fi
 
             if test x"$PKG_CONFIG" != x""; then
                 OPENSSL_LDFLAGS=`$PKG_CONFIG openssl --libs-only-L 2>/dev/null`
@@ -3362,9 +3428,35 @@ $as_echo "yes" >&6; }
 
 else
 
-            { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+            # try adding -ldl to libs before giving up
+            OPENSSL_LIBS="$OPENSSL_LIBS -ldl"
+            LIBS="$OPENSSL_LIBS $save_LIBS"
+            cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#include <openssl/ssl.h>
+int
+main ()
+{
+SSL_new(NULL)
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"; then :
+
+                    { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+
+
+else
+
+                    { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
 $as_echo "no" >&6; }
-            as_fn_error $? "No openssl found." "$LINENO" 5
+                    as_fn_error $? "No openssl found." "$LINENO" 5
+
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
 
 fi
 rm -f core conftest.err conftest.$ac_objext \
@@ -3399,26 +3491,25 @@ else
 
             # if pkg-config is installed and openssl has installed a .pc file,
             # then use that information and don't search ssldirs
-            # Extract the first word of "pkg-config", so it can be a program name with args.
-set dummy pkg-config; ac_word=$2
+            if test -n "$ac_tool_prefix"; then
+  # Extract the first word of "${ac_tool_prefix}pkg-config", so it can be a program name with args.
+set dummy ${ac_tool_prefix}pkg-config; ac_word=$2
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
 $as_echo_n "checking for $ac_word... " >&6; }
-if ${ac_cv_path_PKG_CONFIG+:} false; then :
+if ${ac_cv_prog_PKG_CONFIG+:} false; then :
   $as_echo_n "(cached) " >&6
 else
-  case $PKG_CONFIG in
-  [\\/]* | ?:[\\/]*)
-  ac_cv_path_PKG_CONFIG="$PKG_CONFIG" # Let the user override the test with a path.
-  ;;
-  *)
-  as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+  if test -n "$PKG_CONFIG"; then
+  ac_cv_prog_PKG_CONFIG="$PKG_CONFIG" # Let the user override the test.
+else
+as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
 for as_dir in $PATH
 do
   IFS=$as_save_IFS
   test -z "$as_dir" && as_dir=.
     for ac_exec_ext in '' $ac_executable_extensions; do
   if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
-    ac_cv_path_PKG_CONFIG="$as_dir/$ac_word$ac_exec_ext"
+    ac_cv_prog_PKG_CONFIG="${ac_tool_prefix}pkg-config"
     $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
     break 2
   fi
@@ -3426,10 +3517,9 @@ done
   done
 IFS=$as_save_IFS
 
-  ;;
-esac
 fi
-PKG_CONFIG=$ac_cv_path_PKG_CONFIG
+fi
+PKG_CONFIG=$ac_cv_prog_PKG_CONFIG
 if test -n "$PKG_CONFIG"; then
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: $PKG_CONFIG" >&5
 $as_echo "$PKG_CONFIG" >&6; }
@@ -3438,6 +3528,60 @@ else
 $as_echo "no" >&6; }
 fi
 
+
+fi
+if test -z "$ac_cv_prog_PKG_CONFIG"; then
+  ac_ct_PKG_CONFIG=$PKG_CONFIG
+  # Extract the first word of "pkg-config", so it can be a program name with args.
+set dummy pkg-config; ac_word=$2
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_prog_ac_ct_PKG_CONFIG+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  if test -n "$ac_ct_PKG_CONFIG"; then
+  ac_cv_prog_ac_ct_PKG_CONFIG="$ac_ct_PKG_CONFIG" # Let the user override the test.
+else
+as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+for as_dir in $PATH
+do
+  IFS=$as_save_IFS
+  test -z "$as_dir" && as_dir=.
+    for ac_exec_ext in '' $ac_executable_extensions; do
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
+    ac_cv_prog_ac_ct_PKG_CONFIG="pkg-config"
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
+    break 2
+  fi
+done
+  done
+IFS=$as_save_IFS
+
+fi
+fi
+ac_ct_PKG_CONFIG=$ac_cv_prog_ac_ct_PKG_CONFIG
+if test -n "$ac_ct_PKG_CONFIG"; then
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_ct_PKG_CONFIG" >&5
+$as_echo "$ac_ct_PKG_CONFIG" >&6; }
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+fi
+
+  if test "x$ac_ct_PKG_CONFIG" = x; then
+    PKG_CONFIG=""
+  else
+    case $cross_compiling:$ac_tool_warned in
+yes:)
+{ $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with host triplet" >&5
+$as_echo "$as_me: WARNING: using cross tools not prefixed with host triplet" >&2;}
+ac_tool_warned=yes ;;
+esac
+    PKG_CONFIG=$ac_ct_PKG_CONFIG
+  fi
+else
+  PKG_CONFIG="$ac_cv_prog_PKG_CONFIG"
+fi
 
             if test x"$PKG_CONFIG" != x""; then
                 OPENSSL_LDFLAGS=`$PKG_CONFIG openssl --libs-only-L 2>/dev/null`
@@ -3517,9 +3661,35 @@ $as_echo "yes" >&6; }
 
 else
 
-            { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+            # try adding -ldl to libs before giving up
+            OPENSSL_LIBS="$OPENSSL_LIBS -ldl"
+            LIBS="$OPENSSL_LIBS $save_LIBS"
+            cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#include <openssl/ssl.h>
+int
+main ()
+{
+SSL_new(NULL)
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"; then :
+
+                    { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+
+
+else
+
+                    { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
 $as_echo "no" >&6; }
-            as_fn_error $? "No openssl found. With --disable-openssl, libtgl will use libgcrypt instead." "$LINENO" 5
+                    as_fn_error $? "No openssl found. With --disable-openssl, libtgl will use libgcrypt instead." "$LINENO" 5
+
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
 
 fi
 rm -f core conftest.err conftest.$ac_objext \
@@ -4067,6 +4237,10 @@ $as_echo "#define HAVE_LIBZ 1" >>confdefs.h
 fi
 
 
+#TODO AX_CHECK_ZLIB replace flags. Mustnt do it
+CPPFLAGS=$CPPFLAGS_BUILD
+LDFLAGS=$LDFLAGS_BUILD
+
 # Check whether --enable-extf was given.
 if test "${enable_extf+set}" = set; then :
   enableval=$enable_extf;
@@ -4359,6 +4533,8 @@ _ACEOF
 
 fi
 done
+
+
 
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -9,9 +9,21 @@ m4_include([m4_ax_check_zlib.m4])
 # Checks for programs.
 AC_PROG_CC
 
+#TODO do it better...
+PREFIX_BUILD=${prefix}
+CROSS_COMPILE_BUILD=${build}
+
+if [[ "x$cross_compiling" = "xno" ]]; then
+    PREFIX_BUILD="/usr/local"
+fi
+
 # BSD locations for headers and libraries from packages, Linux locations for self-compiled stuff.
-CPPFLAGS="$CPPFLAGS -I/usr/local/include"
-LDFLAGS="$LDFLAGS -L/usr/local/lib"
+CPPFLAGS="$CPPFLAGS -I${PREFIX_BUILD}/include"
+LDFLAGS="$LDFLAGS -L${PREFIX_BUILD}/lib"
+
+#Backup variables
+CPPFLAGS_BUILD=$CPPFLAGS
+LDFLAGS_BUILD=$LDFLAGS
 
 # Checks for libraries.
 AC_SEARCH_LIBS([clock_gettime], [rt])
@@ -38,6 +50,10 @@ AC_ARG_ENABLE(openssl,[  --disable-openssl	  disables OpenSSL, and don't link ag
   ])
 
 AX_CHECK_ZLIB(, [AC_MSG_ERROR([No zlib found])])
+
+#TODO AX_CHECK_ZLIB replace flags. Mustnt do it
+CPPFLAGS=$CPPFLAGS_BUILD
+LDFLAGS=$LDFLAGS_BUILD
 
 AC_ARG_ENABLE(extf,[  --enable-extf		  enables extended queries system],
   [ 
@@ -87,6 +103,8 @@ AC_CHECK_FUNCS([alarm endpwent malloc memset memmove mkdir realloc select socket
 
 AC_SUBST(EXTRA_LIBS)
 AC_SUBST(EXTRA_OBJECTS)
+AC_SUBST(CROSS_COMPILE_BUILD)
+AC_SUBST(PREFIX_BUILD)
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT
 

--- a/m4_ax_check_openssl.m4
+++ b/m4_ax_check_openssl.m4
@@ -1,5 +1,5 @@
 # ===========================================================================
-#     http://www.gnu.org/software/autoconf-archive/ax_check_openssl.html
+#     https://www.gnu.org/software/autoconf-archive/ax_check_openssl.html
 # ===========================================================================
 #
 # SYNOPSIS
@@ -32,7 +32,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 8
+#serial 10_patch_8498
 
 AU_ALIAS([CHECK_SSL], [AX_CHECK_OPENSSL])
 AC_DEFUN([AX_CHECK_OPENSSL], [
@@ -51,7 +51,7 @@ AC_DEFUN([AX_CHECK_OPENSSL], [
         ], [
             # if pkg-config is installed and openssl has installed a .pc file,
             # then use that information and don't search ssldirs
-            AC_PATH_PROG([PKG_CONFIG], [pkg-config])
+            AC_CHECK_TOOL([PKG_CONFIG], [pkg-config])
             if test x"$PKG_CONFIG" != x""; then
                 OPENSSL_LDFLAGS=`$PKG_CONFIG openssl --libs-only-L 2>/dev/null`
                 if test $? = 0; then
@@ -111,8 +111,18 @@ AC_DEFUN([AX_CHECK_OPENSSL], [
             AC_MSG_RESULT([yes])
             $1
         ], [
-            AC_MSG_RESULT([no])
-            $2
+            # try adding -ldl to libs before giving up
+            OPENSSL_LIBS="$OPENSSL_LIBS -ldl"
+            LIBS="$OPENSSL_LIBS $save_LIBS"
+            AC_LINK_IFELSE(
+                [AC_LANG_PROGRAM([#include <openssl/ssl.h>], [SSL_new(NULL)])],
+                [
+                    AC_MSG_RESULT([yes])
+                    $1
+                ], [
+                    AC_MSG_RESULT([no])
+                    $2
+                ])
         ])
     CPPFLAGS="$save_CPPFLAGS"
     LDFLAGS="$save_LDFLAGS"


### PR DESCRIPTION
Hi,

I've added cross compile support for this library based on the same changes that I made for https://github.com/vk496/tg/tree/endian.

This soluttion have 1 problem: It not verifies the build machine have dependences installed. In stead, it check the **host** and use it config for the **build** (CPPFLAGS, LDFLAGS).

AND seems my toolchain not work properly when compiling the library with some extra stuff of this branch respect the master. I mean, compiling the library using `tg`'s _Makefile.tgl_ work for me. Would be nice to know if is only my problem or not...

My output:

```bash
$ autoreconf -vfi    #Optional
```

```bash
$ ./configure --prefix=/home/vk496/x-tools/mips-malta-linux-gnu/ --host mips-malta-linux-gnu --build x86_64-pc-linux-gnu
checking for mips-malta-linux-gnu-gcc... mips-malta-linux-gnu-gcc
checking whether the C compiler works... yes
checking for C compiler default output file name... a.out
checking for suffix of executables... 
checking whether we are cross compiling... yes
checking for suffix of object files... o
checking whether we are using the GNU C compiler... yes
checking whether mips-malta-linux-gnu-gcc accepts -g... yes
checking for mips-malta-linux-gnu-gcc option to accept ISO C89... none needed
checking for library containing clock_gettime... none required
checking for mips-malta-linux-gnu-pkg-config... no
checking for pkg-config... pkg-config
configure: WARNING: using cross tools not prefixed with host triplet
checking whether compiling and linking against OpenSSL works... yes
checking how to run the C preprocessor... mips-malta-linux-gnu-gcc -E
checking for grep that handles long lines and -e... /usr/bin/grep
checking for egrep... /usr/bin/grep -E
checking for ANSI C header files... yes
checking for sys/types.h... yes
checking for sys/stat.h... yes
checking for stdlib.h... yes
checking for string.h... yes
checking for memory.h... yes
checking for strings.h... yes
checking for inttypes.h... yes
checking for stdint.h... yes
checking for unistd.h... yes
checking if zlib is wanted... yes
checking for inflateEnd in -lz... yes
checking zlib.h usability... yes
checking zlib.h presence... yes
checking for zlib.h... yes
checking fcntl.h usability... yes
checking fcntl.h presence... yes
checking for fcntl.h... yes
checking malloc.h usability... yes
checking malloc.h presence... yes
checking for malloc.h... yes
checking netdb.h usability... yes
checking netdb.h presence... yes
checking for netdb.h... yes
checking for stdlib.h... (cached) yes
checking for string.h... (cached) yes
checking for unistd.h... (cached) yes
checking arpa/inet.h usability... yes
checking arpa/inet.h presence... yes
checking for arpa/inet.h... yes
checking mach/mach.h usability... no
checking mach/mach.h presence... no
checking for mach/mach.h... no
checking netinet/in.h usability... yes
checking netinet/in.h presence... yes
checking for netinet/in.h... yes
checking sys/file.h usability... yes
checking sys/file.h presence... yes
checking for sys/file.h... yes
checking sys/socket.h usability... yes
checking sys/socket.h presence... yes
checking for sys/socket.h... yes
checking termios.h usability... yes
checking termios.h presence... yes
checking for termios.h... yes
checking execinfo.h usability... yes
checking execinfo.h presence... yes
checking for execinfo.h... yes
checking for library containing backtrace_symbols_fd... none required
checking for size_t... yes
checking for uid_t in sys/types.h... yes
checking for inline... inline
checking for alarm... yes
checking for endpwent... yes
checking for malloc... yes
checking for memset... yes
checking for memmove... yes
checking for mkdir... yes
checking for realloc... yes
checking for select... yes
checking for socket... yes
checking for strdup... yes
checking for strndup... yes
checking for uname... yes
configure: creating ./config.status
config.status: creating Makefile
config.status: creating config.h
config.status: config.h is unchanged
```

```bash
$ make -j5
cat scheme.tl encrypted_scheme.tl binlog.tl mtproto.tl append.tl > auto/scheme.tl
x86_64-pc-linux-gnu-gcc -I. -I. -g -O2  -I/usr/local/include  -DHAVE_CONFIG_H -Wall -Wextra -Wno-deprecated-declarations -fno-strict-aliasing -fno-omit-frame-pointer -ggdb -Wno-unused-parameter -fPIC -D_FORTIFY_SOURCE=2 -fstack-protector-strong -iquote ./tl-parser -c -MP -MD -MF dep/tl-parser.d -MQ objs/tl-parser.o -o objs/tl-parser.o tl-parser/tl-parser.c
x86_64-pc-linux-gnu-gcc -I. -I. -g -O2  -I/usr/local/include  -DHAVE_CONFIG_H -Wall -Wextra -Wno-deprecated-declarations -fno-strict-aliasing -fno-omit-frame-pointer -ggdb -Wno-unused-parameter -fPIC -D_FORTIFY_SOURCE=2 -fstack-protector-strong -iquote ./tl-parser -c -MP -MD -MF dep/tlc.d -MQ objs/tlc.o -o objs/tlc.o tl-parser/tlc.c
x86_64-pc-linux-gnu-gcc -I. -I. -g -O2  -I/usr/local/include  -DHAVE_CONFIG_H -Wall -Wextra -Wno-deprecated-declarations -fno-strict-aliasing -fno-omit-frame-pointer -ggdb -Wno-unused-parameter -fPIC -D_FORTIFY_SOURCE=2 -fstack-protector-strong -c -MP -MD -MF dep/generate.native.d -MQ objs/generate.native.o -o objs/generate.native.o generate.c
x86_64-pc-linux-gnu-gcc -I. -I. -g -O2  -I/usr/local/include  -DHAVE_CONFIG_H -Wall -Wextra -Wno-deprecated-declarations -fno-strict-aliasing -fno-omit-frame-pointer -ggdb -Wno-unused-parameter -fPIC -D_FORTIFY_SOURCE=2 -fstack-protector-strong -c -MP -MD -MF dep/tools.native.d -MQ objs/tools.native.o -o objs/tools.native.o tools.c
x86_64-pc-linux-gnu-gcc -I. -I. -g -O2  -I/usr/local/include  -DHAVE_CONFIG_H -Wall -Wextra -Wno-deprecated-declarations -fno-strict-aliasing -fno-omit-frame-pointer -ggdb -Wno-unused-parameter -fPIC -D_FORTIFY_SOURCE=2 -fstack-protector-strong -c -MP -MD -MF dep/crypto/rand_openssl.native.d -MQ objs/crypto/rand_openssl.native.o -o objs/crypto/rand_openssl.native.o crypto/rand_openssl.c
x86_64-pc-linux-gnu-gcc -I. -I. -g -O2  -I/usr/local/include  -DHAVE_CONFIG_H -Wall -Wextra -Wno-deprecated-declarations -fno-strict-aliasing -fno-omit-frame-pointer -ggdb -Wno-unused-parameter -fPIC -D_FORTIFY_SOURCE=2 -fstack-protector-strong -c -MP -MD -MF dep/crypto/rand_altern.native.d -MQ objs/crypto/rand_altern.native.o -o objs/crypto/rand_altern.native.o crypto/rand_altern.c
x86_64-pc-linux-gnu-gcc -I. -I. -g -O2  -I/usr/local/include  -DHAVE_CONFIG_H -Wall -Wextra -Wno-deprecated-declarations -fno-strict-aliasing -fno-omit-frame-pointer -ggdb -Wno-unused-parameter -fPIC -D_FORTIFY_SOURCE=2 -fstack-protector-strong -c -MP -MD -MF dep/crypto/err_openssl.native.d -MQ objs/crypto/err_openssl.native.o -o objs/crypto/err_openssl.native.o crypto/err_openssl.c
x86_64-pc-linux-gnu-gcc -I. -I. -g -O2  -I/usr/local/include  -DHAVE_CONFIG_H -Wall -Wextra -Wno-deprecated-declarations -fno-strict-aliasing -fno-omit-frame-pointer -ggdb -Wno-unused-parameter -fPIC -D_FORTIFY_SOURCE=2 -fstack-protector-strong -c -MP -MD -MF dep/crypto/err_altern.native.d -MQ objs/crypto/err_altern.native.o -o objs/crypto/err_altern.native.o crypto/err_altern.c
mips-malta-linux-gnu-gcc -I. -I. -g -O2  -I/home/vk496/x-tools/mips-malta-linux-gnu/include  -DHAVE_CONFIG_H -Wall -Wextra -Wno-deprecated-declarations -fno-strict-aliasing -fno-omit-frame-pointer -ggdb -Wno-unused-parameter -fPIC -D_FORTIFY_SOURCE=2 -fstack-protector-strong -c -MP -MD -MF dep/tools.d -MQ objs/tools.o -o objs/tools.o tools.c
mips-malta-linux-gnu-gcc -I. -I. -g -O2  -I/home/vk496/x-tools/mips-malta-linux-gnu/include  -DHAVE_CONFIG_H -Wall -Wextra -Wno-deprecated-declarations -fno-strict-aliasing -fno-omit-frame-pointer -ggdb -Wno-unused-parameter -fPIC -D_FORTIFY_SOURCE=2 -fstack-protector-strong -c -MP -MD -MF dep/crypto/rand_openssl.d -MQ objs/crypto/rand_openssl.o -o objs/crypto/rand_openssl.o crypto/rand_openssl.c
mips-malta-linux-gnu-gcc -I. -I. -g -O2  -I/home/vk496/x-tools/mips-malta-linux-gnu/include  -DHAVE_CONFIG_H -Wall -Wextra -Wno-deprecated-declarations -fno-strict-aliasing -fno-omit-frame-pointer -ggdb -Wno-unused-parameter -fPIC -D_FORTIFY_SOURCE=2 -fstack-protector-strong -c -MP -MD -MF dep/crypto/rand_altern.d -MQ objs/crypto/rand_altern.o -o objs/crypto/rand_altern.o crypto/rand_altern.c
mips-malta-linux-gnu-gcc -I. -I. -g -O2  -I/home/vk496/x-tools/mips-malta-linux-gnu/include  -DHAVE_CONFIG_H -Wall -Wextra -Wno-deprecated-declarations -fno-strict-aliasing -fno-omit-frame-pointer -ggdb -Wno-unused-parameter -fPIC -D_FORTIFY_SOURCE=2 -fstack-protector-strong -c -MP -MD -MF dep/crypto/err_openssl.d -MQ objs/crypto/err_openssl.o -o objs/crypto/err_openssl.o crypto/err_openssl.c
mips-malta-linux-gnu-gcc -I. -I. -g -O2  -I/home/vk496/x-tools/mips-malta-linux-gnu/include  -DHAVE_CONFIG_H -Wall -Wextra -Wno-deprecated-declarations -fno-strict-aliasing -fno-omit-frame-pointer -ggdb -Wno-unused-parameter -fPIC -D_FORTIFY_SOURCE=2 -fstack-protector-strong -c -MP -MD -MF dep/crypto/err_altern.d -MQ objs/crypto/err_altern.o -o objs/crypto/err_altern.o crypto/err_altern.c
x86_64-pc-linux-gnu-gcc objs/generate.native.o objs/tools.native.o objs/crypto/rand_openssl.native.o objs/crypto/rand_altern.native.o objs/crypto/err_openssl.native.o objs/crypto/err_altern.native.o -L/usr/local/lib  -rdynamic -ggdb -lz   -lssl -lcrypto -ldl -fPIC -o bin/generate
x86_64-pc-linux-gnu-gcc objs/tl-parser.o objs/tlc.o -L/usr/local/lib  -rdynamic -ggdb -lz   -lssl -lcrypto -ldl -fPIC -o bin/tl-parser
bin/tl-parser -E auto/scheme.tl 2> auto/scheme2.tl  || ( cat auto/scheme2.tl && rm auto/scheme2.tl && false )
bin/tl-parser -e auto/scheme.tlo auto/scheme.tl
awk -f ./gen_constants_h.awk < auto/scheme2.tl > auto/constants.h
bin/generate -g skip-header auto/scheme.tlo > auto/auto-skip.h || ( rm auto/auto-skip.h && false )
bin/generate -g fetch-header auto/scheme.tlo > auto/auto-fetch.h || ( rm auto/auto-fetch.h && false )
bin/generate -g store-header auto/scheme.tlo > auto/auto-store.h || ( rm auto/auto-store.h && false )
bin/generate -g autocomplete-header auto/scheme.tlo > auto/auto-autocomplete.h || ( rm auto/auto-autocomplete.h && false )
bin/generate -g types-header auto/scheme.tlo > auto/auto-types.h || ( rm auto/auto-types.h && false )
bin/generate -g fetch-ds-header auto/scheme.tlo > auto/auto-fetch-ds.h || ( rm auto/auto-fetch-ds.h && false )
bin/generate -g free-ds-header auto/scheme.tlo > auto/auto-free-ds.h || ( rm auto/auto-free-ds.h && false )
bin/generate -g store-ds-header auto/scheme.tlo > auto/auto-store-ds.h || ( rm auto/auto-store-ds.h && false )
bin/generate -g print-ds-header auto/scheme.tlo > auto/auto-print-ds.h || ( rm auto/auto-print-ds.h && false )
bin/generate -g skip auto/scheme.tlo > auto/auto-skip.c || ( rm auto/auto-skip.c && false )
bin/generate -g fetch auto/scheme.tlo > auto/auto-fetch.c || ( rm auto/auto-fetch.c && false )
bin/generate -g store auto/scheme.tlo > auto/auto-store.c || ( rm auto/auto-store.c && false )
bin/generate -g autocomplete auto/scheme.tlo > auto/auto-autocomplete.c || ( rm auto/auto-autocomplete.c && false )
bin/generate -g types auto/scheme.tlo > auto/auto-types.c || ( rm auto/auto-types.c && false )
bin/generate -g fetch-ds auto/scheme.tlo > auto/auto-fetch-ds.c || ( rm auto/auto-fetch-ds.c && false )
bin/generate -g free-ds auto/scheme.tlo > auto/auto-free-ds.c || ( rm auto/auto-free-ds.c && false )
bin/generate -g store-ds auto/scheme.tlo > auto/auto-store-ds.c || ( rm auto/auto-store-ds.c && false )
bin/generate -g print-ds auto/scheme.tlo > auto/auto-print-ds.c || ( rm auto/auto-print-ds.c && false )
mips-malta-linux-gnu-gcc -I. -I. -g -O2  -I/home/vk496/x-tools/mips-malta-linux-gnu/include  -DHAVE_CONFIG_H -Wall -Wextra -Wno-deprecated-declarations -fno-strict-aliasing -fno-omit-frame-pointer -ggdb -Wno-unused-parameter -fPIC -D_FORTIFY_SOURCE=2 -fstack-protector-strong -c -MP -MD -MF dep/mtproto-common.d -MQ objs/mtproto-common.o -o objs/mtproto-common.o mtproto-common.c
mips-malta-linux-gnu-gcc -I. -I. -g -O2  -I/home/vk496/x-tools/mips-malta-linux-gnu/include  -DHAVE_CONFIG_H -Wall -Wextra -Wno-deprecated-declarations -fno-strict-aliasing -fno-omit-frame-pointer -ggdb -Wno-unused-parameter -fPIC -D_FORTIFY_SOURCE=2 -fstack-protector-strong -c -MP -MD -MF dep/mtproto-client.d -MQ objs/mtproto-client.o -o objs/mtproto-client.o mtproto-client.c
mips-malta-linux-gnu-gcc -I. -I. -g -O2  -I/home/vk496/x-tools/mips-malta-linux-gnu/include  -DHAVE_CONFIG_H -Wall -Wextra -Wno-deprecated-declarations -fno-strict-aliasing -fno-omit-frame-pointer -ggdb -Wno-unused-parameter -fPIC -D_FORTIFY_SOURCE=2 -fstack-protector-strong -c -MP -MD -MF dep/mtproto-key.d -MQ objs/mtproto-key.o -o objs/mtproto-key.o mtproto-key.c
mips-malta-linux-gnu-gcc -I. -I. -g -O2  -I/home/vk496/x-tools/mips-malta-linux-gnu/include  -DHAVE_CONFIG_H -Wall -Wextra -Wno-deprecated-declarations -fno-strict-aliasing -fno-omit-frame-pointer -ggdb -Wno-unused-parameter -fPIC -D_FORTIFY_SOURCE=2 -fstack-protector-strong -c -MP -MD -MF dep/queries.d -MQ objs/queries.o -o objs/queries.o queries.c
mips-malta-linux-gnu-gcc -I. -I. -g -O2  -I/home/vk496/x-tools/mips-malta-linux-gnu/include  -DHAVE_CONFIG_H -Wall -Wextra -Wno-deprecated-declarations -fno-strict-aliasing -fno-omit-frame-pointer -ggdb -Wno-unused-parameter -fPIC -D_FORTIFY_SOURCE=2 -fstack-protector-strong -c -MP -MD -MF dep/structures.d -MQ objs/structures.o -o objs/structures.o structures.c
mips-malta-linux-gnu-gcc -I. -I. -g -O2  -I/home/vk496/x-tools/mips-malta-linux-gnu/include  -DHAVE_CONFIG_H -Wall -Wextra -Wno-deprecated-declarations -fno-strict-aliasing -fno-omit-frame-pointer -ggdb -Wno-unused-parameter -fPIC -D_FORTIFY_SOURCE=2 -fstack-protector-strong -c -MP -MD -MF dep/binlog.d -MQ objs/binlog.o -o objs/binlog.o binlog.c
mips-malta-linux-gnu-gcc -I. -I. -g -O2  -I/home/vk496/x-tools/mips-malta-linux-gnu/include  -DHAVE_CONFIG_H -Wall -Wextra -Wno-deprecated-declarations -fno-strict-aliasing -fno-omit-frame-pointer -ggdb -Wno-unused-parameter -fPIC -D_FORTIFY_SOURCE=2 -fstack-protector-strong -c -MP -MD -MF dep/tgl.d -MQ objs/tgl.o -o objs/tgl.o tgl.c
mips-malta-linux-gnu-gcc -I. -I. -g -O2  -I/home/vk496/x-tools/mips-malta-linux-gnu/include  -DHAVE_CONFIG_H -Wall -Wextra -Wno-deprecated-declarations -fno-strict-aliasing -fno-omit-frame-pointer -ggdb -Wno-unused-parameter -fPIC -D_FORTIFY_SOURCE=2 -fstack-protector-strong -c -MP -MD -MF dep/updates.d -MQ objs/updates.o -o objs/updates.o updates.c
mips-malta-linux-gnu-gcc -I. -I. -g -O2  -I/home/vk496/x-tools/mips-malta-linux-gnu/include  -DHAVE_CONFIG_H -Wall -Wextra -Wno-deprecated-declarations -fno-strict-aliasing -fno-omit-frame-pointer -ggdb -Wno-unused-parameter -fPIC -D_FORTIFY_SOURCE=2 -fstack-protector-strong -c -MP -MD -MF dep/tg-mime-types.d -MQ objs/tg-mime-types.o -o objs/tg-mime-types.o tg-mime-types.c
mips-malta-linux-gnu-gcc -I. -I. -g -O2  -I/home/vk496/x-tools/mips-malta-linux-gnu/include  -DHAVE_CONFIG_H -Wall -Wextra -Wno-deprecated-declarations -fno-strict-aliasing -fno-omit-frame-pointer -ggdb -Wno-unused-parameter -fPIC -D_FORTIFY_SOURCE=2 -fstack-protector-strong -c -MP -MD -MF dep/mtproto-utils.d -MQ objs/mtproto-utils.o -o objs/mtproto-utils.o mtproto-utils.c
mips-malta-linux-gnu-gcc -I. -I. -g -O2  -I/home/vk496/x-tools/mips-malta-linux-gnu/include  -DHAVE_CONFIG_H -Wall -Wextra -Wno-deprecated-declarations -fno-strict-aliasing -fno-omit-frame-pointer -ggdb -Wno-unused-parameter -fPIC -D_FORTIFY_SOURCE=2 -fstack-protector-strong -c -MP -MD -MF dep/crypto/bn_openssl.d -MQ objs/crypto/bn_openssl.o -o objs/crypto/bn_openssl.o crypto/bn_openssl.c
mips-malta-linux-gnu-gcc -I. -I. -g -O2  -I/home/vk496/x-tools/mips-malta-linux-gnu/include  -DHAVE_CONFIG_H -Wall -Wextra -Wno-deprecated-declarations -fno-strict-aliasing -fno-omit-frame-pointer -ggdb -Wno-unused-parameter -fPIC -D_FORTIFY_SOURCE=2 -fstack-protector-strong -c -MP -MD -MF dep/crypto/bn_altern.d -MQ objs/crypto/bn_altern.o -o objs/crypto/bn_altern.o crypto/bn_altern.c
mips-malta-linux-gnu-gcc -I. -I. -g -O2  -I/home/vk496/x-tools/mips-malta-linux-gnu/include  -DHAVE_CONFIG_H -Wall -Wextra -Wno-deprecated-declarations -fno-strict-aliasing -fno-omit-frame-pointer -ggdb -Wno-unused-parameter -fPIC -D_FORTIFY_SOURCE=2 -fstack-protector-strong -c -MP -MD -MF dep/crypto/rsa_pem_openssl.d -MQ objs/crypto/rsa_pem_openssl.o -o objs/crypto/rsa_pem_openssl.o crypto/rsa_pem_openssl.c
mips-malta-linux-gnu-gcc -I. -I. -g -O2  -I/home/vk496/x-tools/mips-malta-linux-gnu/include  -DHAVE_CONFIG_H -Wall -Wextra -Wno-deprecated-declarations -fno-strict-aliasing -fno-omit-frame-pointer -ggdb -Wno-unused-parameter -fPIC -D_FORTIFY_SOURCE=2 -fstack-protector-strong -c -MP -MD -MF dep/crypto/rsa_pem_altern.d -MQ objs/crypto/rsa_pem_altern.o -o objs/crypto/rsa_pem_altern.o crypto/rsa_pem_altern.c
mips-malta-linux-gnu-gcc -I. -I. -g -O2  -I/home/vk496/x-tools/mips-malta-linux-gnu/include  -DHAVE_CONFIG_H -Wall -Wextra -Wno-deprecated-declarations -fno-strict-aliasing -fno-omit-frame-pointer -ggdb -Wno-unused-parameter -fPIC -D_FORTIFY_SOURCE=2 -fstack-protector-strong -c -MP -MD -MF dep/crypto/md5_openssl.d -MQ objs/crypto/md5_openssl.o -o objs/crypto/md5_openssl.o crypto/md5_openssl.c
mips-malta-linux-gnu-gcc -I. -I. -g -O2  -I/home/vk496/x-tools/mips-malta-linux-gnu/include  -DHAVE_CONFIG_H -Wall -Wextra -Wno-deprecated-declarations -fno-strict-aliasing -fno-omit-frame-pointer -ggdb -Wno-unused-parameter -fPIC -D_FORTIFY_SOURCE=2 -fstack-protector-strong -c -MP -MD -MF dep/crypto/md5_altern.d -MQ objs/crypto/md5_altern.o -o objs/crypto/md5_altern.o crypto/md5_altern.c
mips-malta-linux-gnu-gcc -I. -I. -g -O2  -I/home/vk496/x-tools/mips-malta-linux-gnu/include  -DHAVE_CONFIG_H -Wall -Wextra -Wno-deprecated-declarations -fno-strict-aliasing -fno-omit-frame-pointer -ggdb -Wno-unused-parameter -fPIC -D_FORTIFY_SOURCE=2 -fstack-protector-strong -c -MP -MD -MF dep/crypto/sha_openssl.d -MQ objs/crypto/sha_openssl.o -o objs/crypto/sha_openssl.o crypto/sha_openssl.c
mips-malta-linux-gnu-gcc -I. -I. -g -O2  -I/home/vk496/x-tools/mips-malta-linux-gnu/include  -DHAVE_CONFIG_H -Wall -Wextra -Wno-deprecated-declarations -fno-strict-aliasing -fno-omit-frame-pointer -ggdb -Wno-unused-parameter -fPIC -D_FORTIFY_SOURCE=2 -fstack-protector-strong -c -MP -MD -MF dep/crypto/sha_altern.d -MQ objs/crypto/sha_altern.o -o objs/crypto/sha_altern.o crypto/sha_altern.c
mips-malta-linux-gnu-gcc -I. -I. -g -O2  -I/home/vk496/x-tools/mips-malta-linux-gnu/include  -DHAVE_CONFIG_H -Wall -Wextra -Wno-deprecated-declarations -fno-strict-aliasing -fno-omit-frame-pointer -ggdb -Wno-unused-parameter -fPIC -D_FORTIFY_SOURCE=2 -fstack-protector-strong -c -MP -MD -MF dep/crypto/aes_openssl.d -MQ objs/crypto/aes_openssl.o -o objs/crypto/aes_openssl.o crypto/aes_openssl.c
mips-malta-linux-gnu-gcc -I. -I. -g -O2  -I/home/vk496/x-tools/mips-malta-linux-gnu/include  -DHAVE_CONFIG_H -Wall -Wextra -Wno-deprecated-declarations -fno-strict-aliasing -fno-omit-frame-pointer -ggdb -Wno-unused-parameter -fPIC -D_FORTIFY_SOURCE=2 -fstack-protector-strong -c -MP -MD -MF dep/crypto/aes_altern.d -MQ objs/crypto/aes_altern.o -o objs/crypto/aes_altern.o crypto/aes_altern.c
mips-malta-linux-gnu-gcc -I. -I. -g -O2  -I/home/vk496/x-tools/mips-malta-linux-gnu/include  -DHAVE_CONFIG_H -Wall -Wextra -Wno-deprecated-declarations -fno-strict-aliasing -fno-omit-frame-pointer -ggdb -Wno-unused-parameter -fPIC -D_FORTIFY_SOURCE=2 -fstack-protector-strong -iquote ./tgl -c -MP -MD -MF dep/auto-skip.d -MQ objs/auto-skip.o -o objs/auto/auto-skip.o auto/auto-skip.c
mips-malta-linux-gnu-gcc -I. -I. -g -O2  -I/home/vk496/x-tools/mips-malta-linux-gnu/include  -DHAVE_CONFIG_H -Wall -Wextra -Wno-deprecated-declarations -fno-strict-aliasing -fno-omit-frame-pointer -ggdb -Wno-unused-parameter -fPIC -D_FORTIFY_SOURCE=2 -fstack-protector-strong -iquote ./tgl -c -MP -MD -MF dep/auto-fetch.d -MQ objs/auto-fetch.o -o objs/auto/auto-fetch.o auto/auto-fetch.c
mips-malta-linux-gnu-gcc -I. -I. -g -O2  -I/home/vk496/x-tools/mips-malta-linux-gnu/include  -DHAVE_CONFIG_H -Wall -Wextra -Wno-deprecated-declarations -fno-strict-aliasing -fno-omit-frame-pointer -ggdb -Wno-unused-parameter -fPIC -D_FORTIFY_SOURCE=2 -fstack-protector-strong -iquote ./tgl -c -MP -MD -MF dep/auto-store.d -MQ objs/auto-store.o -o objs/auto/auto-store.o auto/auto-store.c
mips-malta-linux-gnu-gcc -I. -I. -g -O2  -I/home/vk496/x-tools/mips-malta-linux-gnu/include  -DHAVE_CONFIG_H -Wall -Wextra -Wno-deprecated-declarations -fno-strict-aliasing -fno-omit-frame-pointer -ggdb -Wno-unused-parameter -fPIC -D_FORTIFY_SOURCE=2 -fstack-protector-strong -iquote ./tgl -c -MP -MD -MF dep/auto-autocomplete.d -MQ objs/auto-autocomplete.o -o objs/auto/auto-autocomplete.o auto/auto-autocomplete.c
mips-malta-linux-gnu-gcc -I. -I. -g -O2  -I/home/vk496/x-tools/mips-malta-linux-gnu/include  -DHAVE_CONFIG_H -Wall -Wextra -Wno-deprecated-declarations -fno-strict-aliasing -fno-omit-frame-pointer -ggdb -Wno-unused-parameter -fPIC -D_FORTIFY_SOURCE=2 -fstack-protector-strong -iquote ./tgl -c -MP -MD -MF dep/auto-types.d -MQ objs/auto-types.o -o objs/auto/auto-types.o auto/auto-types.c
mips-malta-linux-gnu-gcc -I. -I. -g -O2  -I/home/vk496/x-tools/mips-malta-linux-gnu/include  -DHAVE_CONFIG_H -Wall -Wextra -Wno-deprecated-declarations -fno-strict-aliasing -fno-omit-frame-pointer -ggdb -Wno-unused-parameter -fPIC -D_FORTIFY_SOURCE=2 -fstack-protector-strong -iquote ./tgl -c -MP -MD -MF dep/auto-fetch-ds.d -MQ objs/auto-fetch-ds.o -o objs/auto/auto-fetch-ds.o auto/auto-fetch-ds.c
mips-malta-linux-gnu-gcc -I. -I. -g -O2  -I/home/vk496/x-tools/mips-malta-linux-gnu/include  -DHAVE_CONFIG_H -Wall -Wextra -Wno-deprecated-declarations -fno-strict-aliasing -fno-omit-frame-pointer -ggdb -Wno-unused-parameter -fPIC -D_FORTIFY_SOURCE=2 -fstack-protector-strong -iquote ./tgl -c -MP -MD -MF dep/auto-free-ds.d -MQ objs/auto-free-ds.o -o objs/auto/auto-free-ds.o auto/auto-free-ds.c
mips-malta-linux-gnu-gcc -I. -I. -g -O2  -I/home/vk496/x-tools/mips-malta-linux-gnu/include  -DHAVE_CONFIG_H -Wall -Wextra -Wno-deprecated-declarations -fno-strict-aliasing -fno-omit-frame-pointer -ggdb -Wno-unused-parameter -fPIC -D_FORTIFY_SOURCE=2 -fstack-protector-strong -iquote ./tgl -c -MP -MD -MF dep/auto-store-ds.d -MQ objs/auto-store-ds.o -o objs/auto/auto-store-ds.o auto/auto-store-ds.c
mips-malta-linux-gnu-gcc -I. -I. -g -O2  -I/home/vk496/x-tools/mips-malta-linux-gnu/include  -DHAVE_CONFIG_H -Wall -Wextra -Wno-deprecated-declarations -fno-strict-aliasing -fno-omit-frame-pointer -ggdb -Wno-unused-parameter -fPIC -D_FORTIFY_SOURCE=2 -fstack-protector-strong -iquote ./tgl -c -MP -MD -MF dep/auto-print-ds.d -MQ objs/auto-print-ds.o -o objs/auto/auto-print-ds.o auto/auto-print-ds.c
rm -f libs/libtgl.a && ar ruv libs/libtgl.a objs/mtproto-common.o objs/mtproto-client.o objs/mtproto-key.o objs/queries.o objs/structures.o objs/binlog.o objs/tgl.o objs/updates.o objs/tg-mime-types.o objs/mtproto-utils.o objs/crypto/bn_openssl.o objs/crypto/bn_altern.o objs/crypto/rsa_pem_openssl.o objs/crypto/rsa_pem_altern.o objs/crypto/md5_openssl.o objs/crypto/md5_altern.o objs/crypto/sha_openssl.o objs/crypto/sha_altern.o objs/crypto/aes_openssl.o objs/crypto/aes_altern.o objs/tools.o objs/crypto/rand_openssl.o objs/crypto/rand_altern.o objs/crypto/err_openssl.o objs/crypto/err_altern.o objs/auto/auto-skip.o objs/auto/auto-fetch.o objs/auto/auto-store.o objs/auto/auto-autocomplete.o objs/auto/auto-types.o objs/auto/auto-fetch-ds.o objs/auto/auto-free-ds.o objs/auto/auto-store-ds.o objs/auto/auto-print-ds.o
mips-malta-linux-gnu-gcc -shared -o libs/libtgl.so objs/mtproto-common.o objs/mtproto-client.o objs/mtproto-key.o objs/queries.o objs/structures.o objs/binlog.o objs/tgl.o objs/updates.o objs/tg-mime-types.o objs/mtproto-utils.o objs/crypto/bn_openssl.o objs/crypto/bn_altern.o objs/crypto/rsa_pem_openssl.o objs/crypto/rsa_pem_altern.o objs/crypto/md5_openssl.o objs/crypto/md5_altern.o objs/crypto/sha_openssl.o objs/crypto/sha_altern.o objs/crypto/aes_openssl.o objs/crypto/aes_altern.o objs/tools.o objs/crypto/rand_openssl.o objs/crypto/rand_altern.o objs/crypto/err_openssl.o objs/crypto/err_altern.o objs/auto/auto-skip.o objs/auto/auto-fetch.o objs/auto/auto-store.o objs/auto/auto-autocomplete.o objs/auto/auto-types.o objs/auto/auto-fetch-ds.o objs/auto/auto-free-ds.o objs/auto/auto-store-ds.o objs/auto/auto-print-ds.o -L/home/vk496/x-tools/mips-malta-linux-gnu/lib  -rdynamic -ggdb -lz   -lssl -lcrypto -ldl -fPIC
ar: `u' modifier ignored since `D' is the default (see `U')
ar: creando libs/libtgl.a
a - objs/mtproto-common.o
a - objs/mtproto-client.o
a - objs/mtproto-key.o
a - objs/queries.o
a - objs/structures.o
a - objs/binlog.o
a - objs/tgl.o
a - objs/updates.o
a - objs/tg-mime-types.o
a - objs/mtproto-utils.o
a - objs/crypto/bn_openssl.o
a - objs/crypto/bn_altern.o
a - objs/crypto/rsa_pem_openssl.o
a - objs/crypto/rsa_pem_altern.o
a - objs/crypto/md5_openssl.o
a - objs/crypto/md5_altern.o
a - objs/crypto/sha_openssl.o
a - objs/crypto/sha_altern.o
a - objs/crypto/aes_openssl.o
a - objs/crypto/aes_altern.o
a - objs/tools.o
a - objs/crypto/rand_openssl.o
a - objs/crypto/rand_altern.o
a - objs/crypto/err_openssl.o
a - objs/crypto/err_altern.o
a - objs/auto/auto-skip.o
a - objs/auto/auto-fetch.o
a - objs/auto/auto-store.o
a - objs/auto/auto-autocomplete.o
a - objs/auto/auto-types.o
a - objs/auto/auto-fetch-ds.o
a - objs/auto/auto-free-ds.o
a - objs/auto/auto-store-ds.o
a - objs/auto/auto-print-ds.o
/home/vk496/x-tools/mips-malta-linux-gnu/lib/gcc/mips-malta-linux-gnu/7.1.0/../../../../mips-malta-linux-gnu/bin/ld: /home/vk496/x-tools/mips-malta-linux-gnu/lib/libcrypto.a(md5_one.o): relocation R_MIPS_26 against `MD5_Init' can not be used when making a shared object; recompile with -fPIC
/home/vk496/x-tools/mips-malta-linux-gnu/lib/libcrypto.a: error adding symbols: Bad value
collect2: error: ld returned 1 exit status
make: *** [Makefile:87: libs/libtgl.so] Error 1
```