### PR TITLE
Use correct macro to distinguish between Darwin and not (Hurd)

### DIFF
--- a/mtproto-client.c
+++ b/mtproto-client.c
@@ -1155,7 +1155,7 @@ static int rpc_execute (struct tgl_state *TLS, struct connection *c, int op, int
   vlogprintf (E_DEBUG, "Response_len = %d\n", Response_len);
   assert (TLS->net_methods->read_in (c, Response, Response_len) == Response_len);
 
-#if !defined(__MACH__) && !defined(__FreeBSD__) && !defined(__OpenBSD__) && !defined (__CYGWIN__)
+#if !defined(__APPLE__) && !defined(__FreeBSD__) && !defined(__OpenBSD__) && !defined (__CYGWIN__)
 //  setsockopt (c->fd, IPPROTO_TCP, TCP_QUICKACK, (int[]){0}, 4);
 #endif
   int o = DC->state;

--- a/mtproto-common.c
+++ b/mtproto-common.c
@@ -45,7 +45,7 @@
 #include "mtproto-common.h"
 #include "tools.h"
 
-#ifdef __MACH__
+#ifdef __APPLE__
 #include <mach/clock.h>
 #include <mach/mach.h>
 #endif

--- a/tools.c
+++ b/tools.c
@@ -36,7 +36,7 @@
 //#include "interface.h"
 #include "tools.h"
 
-#ifdef __MACH__
+#ifdef __APPLE__
 #include <mach/clock.h>
 #include <mach/mach.h>
 #endif
@@ -298,7 +298,7 @@ void tgl_exists_release (void *ptr, int size) {}
 void tgl_check_release (void) {}
 
 void tgl_my_clock_gettime (int clock_id, struct timespec *T) {
-#ifdef __MACH__
+#ifdef __APPLE__
   // We are ignoring MONOTONIC and hope time doesn't go back too often
   clock_serv_t cclock;
   mach_timespec_t mts;


### PR DESCRIPTION
The `__MACH__` macro is set on multiple systems, such as GNU/Hurd, not just on Darwin (Mac OS X), so use `__GNU__` for the former, `__APPLE__` for Darwin.

See also: https://bugs.debian.org/701764#3